### PR TITLE
Google Analyticsを@next/third-partiesに移行してパフォーマンスを改善

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
 		"seed": "pnpm dlx tsx prisma/seed.ts"
 	},
 	"dependencies": {
+		"@next/third-parties": "15.5.6",
 		"@prisma/client": "6.15.0",
 		"@radix-ui/react-alert-dialog": "1.0.4",
 		"@radix-ui/react-dialog": "1.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@next/third-parties':
+        specifier: 15.5.6
+        version: 15.5.6(next@15.5.6(@babel/core@7.28.4)(@playwright/test@1.38.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)
       '@prisma/client':
         specifier: 6.15.0
         version: 6.15.0(prisma@6.15.0(typescript@5.9.3))(typescript@5.9.3)
@@ -961,6 +964,12 @@ packages:
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
+
+  '@next/third-parties@15.5.6':
+    resolution: {integrity: sha512-B1BLvEi7edGERNN0njxpiqbqkp3zAZ69eJ5C0vwj/XINRzcC25b9MCqxbSHq094d306H65UnlhEkBv+a8c74iA==}
+    peerDependencies:
+      next: ^13.0.0 || ^14.0.0 || ^15.0.0
+      react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -2670,6 +2679,9 @@ packages:
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
+  third-party-capital@1.0.20:
+    resolution: {integrity: sha512-oB7yIimd8SuGptespDAZnNkzIz+NWaJCu2RMsbs4Wmp9zSDUM8Nhi3s2OOcqYuv3mN4hitXc8DVx+LyUmbUDiA==}
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -3634,6 +3646,12 @@ snapshots:
 
   '@next/swc-win32-x64-msvc@15.5.6':
     optional: true
+
+  '@next/third-parties@15.5.6(next@15.5.6(@babel/core@7.28.4)(@playwright/test@1.38.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      next: 15.5.6(@babel/core@7.28.4)(@playwright/test@1.38.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      react: 19.1.1
+      third-party-capital: 1.0.20
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -5348,6 +5366,8 @@ snapshots:
   thenify@3.3.1:
     dependencies:
       any-promise: 1.3.0
+
+  third-party-capital@1.0.20: {}
 
   tinybench@2.9.0: {}
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,10 +1,10 @@
 import "./globals.css";
 
 import type { Metadata } from "next";
+import { GoogleAnalytics } from "@next/third-parties/google";
 import { M_PLUS_Rounded_1c, Montserrat } from "next/font/google";
 import Image from "next/image";
 import Link from "next/link";
-import Script from "next/script";
 
 import Mark from "./mark.svg";
 
@@ -44,9 +44,6 @@ export default function RootLayout({
 }) {
 	return (
 		<html lang="ja">
-			<head>
-				<GoogleAnalytics />
-			</head>
 			<body
 				className={`${baseFont.className} flex h-[100dvh] flex-col overflow-hidden`}
 			>
@@ -58,27 +55,7 @@ export default function RootLayout({
 				</header>
 				<main className="flex grow flex-col overflow-y-hidden">{children}</main>
 			</body>
+			<GoogleAnalytics gaId="G-30177J9MB5" />
 		</html>
-	);
-}
-
-function GoogleAnalytics() {
-	return (
-		<>
-			<Script
-				async
-				src="https://www.googletagmanager.com/gtag/js?id=G-30177J9MB5"
-			/>
-			{/* biome-ignore lint/correctness/useUniqueElementIds: Next.js Script requires static ID */}
-			<Script id="google-analytics">
-				{`
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'G-30177J9MB5');
-  `}
-			</Script>
-		</>
 	);
 }


### PR DESCRIPTION
## 概要
Google Analyticsの読み込み方法を、手動のScriptコンポーネントからNext.js公式の`@next/third-parties`パッケージに移行しました。

## 変更内容
- ✅ `@next/third-parties`パッケージを追加
- ✅ `layout.tsx`でGoogleAnalyticsコンポーネントを`@next/third-parties`から使用
- ✅ 独自実装のGoogleAnalytics関数コンポーネントを削除
- ✅ `next/script`の`Script`コンポーネントのインポートを削除
- ✅ `GoogleAnalytics`コンポーネントを`<body>`タグの外側に配置（Next.js推奨）

## 期待される効果
- ⚡ Next.jsチームによる最適化されたスクリプト読み込み戦略を使用
- 🔧 コードのシンプル化とメンテナンス性向上
- ✨ Next.jsのベストプラクティスに準拠

## テスト
- ✅ `pnpm validate:check` 成功
  - format:check ✅
  - lint:check ✅
  - type:check ✅
  - spell:check ✅
  - knip:check ✅

## 参考
- [Next.js Third Parties Documentation](https://nextjs.org/docs/app/building-your-application/optimizing/third-party-libraries)
- [Google Analytics Component](https://nextjs.org/docs/app/building-your-application/optimizing/third-party-libraries#google-analytics)

🤖 Generated with [Claude Code](https://claude.com/claude-code)