### PR TITLE
ビンゴ開始ボタンにローディングアニメーションを追加

### DIFF
--- a/src/app/bingo-start-button.tsx
+++ b/src/app/bingo-start-button.tsx
@@ -1,10 +1,9 @@
 "use client";
 
+import { ReloadIcon } from "@radix-ui/react-icons";
 import { useRouter } from "next/navigation";
 import { useState, useTransition } from "react";
-
 import { Button } from "@/components/ui/button";
-
 import { startBingoGame } from "./start-bingo-game";
 
 export function BingoStartButton() {
@@ -41,11 +40,15 @@ export function BingoStartButton() {
 		<div className="flex flex-col items-center">
 			<Button
 				type="button"
-				className="max-w-[220px]"
+				className="min-w-[220px]"
 				onClick={handleClick}
 				disabled={isPending}
 			>
-				ビンゴゲームを開始する
+				{isPending ? (
+					<ReloadIcon className="animate-spin" />
+				) : (
+					"ビンゴゲームを開始する"
+				)}
 			</Button>
 			{errorMessage && (
 				<div className="mt-4 text-destructive border border-destructive rounded-lg p-2">


### PR DESCRIPTION
## Summary
- isPending が true の場合に回転する ReloadIcon を表示
- ボタン幅を `min-w-[220px]` に設定し、ローディング中もボタンサイズを維持
- ユーザー環境によるフォントサイズの変動に対応

## Test plan
- [ ] ビンゴ開始ボタンをクリックして、ローディング中に回転アイコンが表示されることを確認
- [ ] ローディング中もボタンサイズが変わらないことを確認
- [ ] 正常にビンゴゲームが開始されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)