### PR TITLE
BingoGameからhashedManagementPasswordフィールドを削除

### DIFF
--- a/src/domains/BingoGame/infrastructures/InMemoryBingoGame.query.ts
+++ b/src/domains/BingoGame/infrastructures/InMemoryBingoGame.query.ts
@@ -22,11 +22,8 @@ export class InMemoryBingoGameQuery implements BingoGameQuery {
 			(card) => card.bingoGameId === bingoGameViewId,
 		);
 
-		const { hashedManagementPassword: _, ...bingoGameDtoWithoutBingoCardIds } =
-			bingoGame;
-
 		return {
-			...bingoGameDtoWithoutBingoCardIds,
+			...bingoGame,
 			bingoCards,
 		};
 	}
@@ -43,11 +40,8 @@ export class InMemoryBingoGameQuery implements BingoGameQuery {
 			(card) => card.bingoGameId === bingoGameId,
 		);
 
-		const { hashedManagementPassword: _, ...bingoGameDtoWithoutBingoCardIds } =
-			bingoGame;
-
 		return {
-			...bingoGameDtoWithoutBingoCardIds,
+			...bingoGame,
 			bingoCards,
 		};
 	}

--- a/src/domains/BingoGame/infrastructures/PrismaBingoGame.repository.ts
+++ b/src/domains/BingoGame/infrastructures/PrismaBingoGame.repository.ts
@@ -16,17 +16,12 @@ export class PrismaBingoGameRepository implements BingoGameRepository {
 			id: bingoGame.id,
 			lotteryNumbers: bingoGame.lotteryNumbers,
 			viewId: bingoGame.viewId,
-			hashedManagementPassword: null,
 			state: "created",
 		});
 	}
 
 	async save(bingoGame: BingoGame): Promise<void> {
-		const {
-			hashedManagementPassword: _,
-			state: __,
-			...bingoGameDto
-		} = bingoGame.toDto();
+		const { state: _, ...bingoGameDto } = bingoGame.toDto();
 		await prisma.bingoGameEntity.upsert({
 			where: { id: bingoGame.id },
 			create: bingoGameDto,

--- a/src/domains/BingoGame/models/BingoGame.ts
+++ b/src/domains/BingoGame/models/BingoGame.ts
@@ -12,7 +12,6 @@ export interface BingoGameDto {
 	lotteryNumbers: number[];
 	viewId: string;
 	state: BingoGameState;
-	hashedManagementPassword: string | null;
 }
 
 export class BingoGame {
@@ -31,7 +30,6 @@ export class BingoGame {
 			id: crypto.randomUUID(),
 			lotteryNumbers: [],
 			viewId: crypto.randomUUID(),
-			hashedManagementPassword: null,
 			state: BingoGameStateEnum.CREATED,
 		});
 	}

--- a/src/domains/BingoGame/models/BingoGame.unit.spec.ts
+++ b/src/domains/BingoGame/models/BingoGame.unit.spec.ts
@@ -13,7 +13,6 @@ describe("BingoGame", () => {
 				id: expect.any(String),
 				lotteryNumbers: [],
 				viewId: expect.any(String),
-				hashedManagementPassword: null,
 				state: CREATED,
 			});
 		});

--- a/src/domains/BingoGame/usecases/BingoGame.query.ts
+++ b/src/domains/BingoGame/usecases/BingoGame.query.ts
@@ -4,15 +4,12 @@ import type { BingoGameDto } from "../models/BingoGame";
 
 export type BingoGameViewDtoWithCards = Omit<
 	BingoGameDto,
-	"hashedManagementPassword" | "bingoCardIds" | "id"
+	"bingoCardIds" | "id"
 > & {
 	bingoCards: Omit<BingoCardDto, "bingoGameId">[];
 };
 
-export type BingoGameDtoWithCards = Omit<
-	BingoGameDto,
-	"hashedManagementPassword" | "bingoCardIds"
-> & {
+export type BingoGameDtoWithCards = Omit<BingoGameDto, "bingoCardIds"> & {
 	bingoCards: BingoCardDto[];
 };
 

--- a/src/domains/BingoGame/usecases/BingoGameCreate.usecase.ts
+++ b/src/domains/BingoGame/usecases/BingoGameCreate.usecase.ts
@@ -1,7 +1,7 @@
 import { BingoGame, type BingoGameDto } from "../models/BingoGame";
 import type { BingoGameRepository } from "./BingoGame.repository";
 
-type BingoGameCreateDto = Omit<BingoGameDto, "hashedManagementPassword">;
+type BingoGameCreateDto = BingoGameDto;
 
 export class BingoGameCreateUsecase {
 	constructor(private readonly bingoGameRepository: BingoGameRepository) {}
@@ -11,9 +11,6 @@ export class BingoGameCreateUsecase {
 
 		await this.bingoGameRepository.save(bingoGame);
 
-		const { hashedManagementPassword: _, ...bingoGameCreateDto } =
-			bingoGame.toDto();
-
-		return bingoGameCreateDto;
+		return bingoGame.toDto();
 	}
 }

--- a/src/domains/BingoGame/usecases/BingoGameCreate.usecase.unit-spec.ts
+++ b/src/domains/BingoGame/usecases/BingoGameCreate.usecase.unit-spec.ts
@@ -26,10 +26,7 @@ describe("BingoGameCreateUsecase", () => {
 				lotteryNumbers: [],
 				viewId: expect.any(String),
 				state: CREATED,
-				bingoCardIds: [],
 			});
-
-			expect(bingoGame).not.toHaveProperty("hashedManagementPassword");
 		});
 	});
 });

--- a/src/domains/BingoGame/usecases/BingoGameDrawLotteryNumber.usecase.ts
+++ b/src/domains/BingoGame/usecases/BingoGameDrawLotteryNumber.usecase.ts
@@ -1,10 +1,7 @@
 import type { BingoGameDto } from "../models/BingoGame";
 import type { BingoGameRepository } from "./BingoGame.repository";
 
-type BingoGameDrawLotteryNumberDto = Omit<
-	BingoGameDto,
-	"hashedManagementPassword"
->;
+type BingoGameDrawLotteryNumberDto = BingoGameDto;
 
 export class BingoGameDrawLotteryNumberUsecase {
 	constructor(private readonly bingoGameRepository: BingoGameRepository) {}
@@ -19,9 +16,6 @@ export class BingoGameDrawLotteryNumberUsecase {
 
 		await this.bingoGameRepository.save(bingoGame);
 
-		const { hashedManagementPassword: _, ...bingoGameDrawLotteryNumberDto } =
-			bingoGame.toDto();
-
-		return bingoGameDrawLotteryNumberDto;
+		return bingoGame.toDto();
 	}
 }

--- a/src/domains/BingoGame/usecases/BingoGameDrawLotteryNumber.usecase.unit-spec.ts
+++ b/src/domains/BingoGame/usecases/BingoGameDrawLotteryNumber.usecase.unit-spec.ts
@@ -25,10 +25,7 @@ describe("BingoGameDrawLotteryNumber", () => {
 				viewId: expect.any(String),
 				lotteryNumbers: expect.any(Array),
 				state: PLAYING,
-				bingoCardIds: expect.any(Array),
 			});
-
-			expect(bingoGameDto).not.toHaveProperty("hashedManagementPassword");
 		});
 
 		it("存在しない ID を指定したときに例外が発生する", async () => {


### PR DESCRIPTION
## 概要
- BingoGameモデルから`hashedManagementPassword`フィールドを削除
- 管理パスワードのハッシュ化機能を廃止し、ドメインモデルを簡素化

## 変更内容
- `BingoGameDto`インターフェースから`hashedManagementPassword`フィールドを削除
- `InMemoryBingoGameQuery`で`hashedManagementPassword`を除外する処理を削除
- `PrismaBingoGameRepository`で`hashedManagementPassword`の処理を削除
- 各ユースケース（`BingoGameCreate`、`BingoGameDrawLotteryNumber`）で`hashedManagementPassword`を除外する処理を削除
- 型定義から`hashedManagementPassword`の除外処理を削除
- ユニットテストから関連するテストケースを削除

## テスト計画
- [ ] ユニットテストが正常に実行されることを確認
- [ ] BingoGame作成機能が正常に動作することを確認
- [ ] 抽選機能が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)