### PR TITLE
ビンゴゲームのe2eテストを実装

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
   prepare:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - uses: actions/setup-node@v6
         with:
           node-version: 18
@@ -37,7 +37,7 @@ jobs:
     needs: prepare
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - uses: actions/setup-node@v6
         with:
           node-version: 18
@@ -53,7 +53,7 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - uses: actions/setup-node@v6
         with:
           node-version: 18
@@ -79,7 +79,7 @@ jobs:
     needs: prepare
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - uses: actions/setup-node@v6
         with:
           node-version: 18
@@ -95,7 +95,7 @@ jobs:
     needs: prepare
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - uses: actions/setup-node@v6
         with:
           node-version: 18

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,33 +48,6 @@ jobs:
       - name: execute
         run: npm run test:unit
 
-  e2e:
-    needs: prepare
-    timeout-minutes: 10
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 18
-          cache: npm
-          cache-dependency-path: ./**/package-lock.json
-      - name: Install dependency
-        run: npm ci
-      - name: execute
-        working-directory: ./bingo-web
-        run: npm run format:check
-      - name: Install Playwright Browsers
-        run: npx playwright install --with-deps
-      - name: Run Playwright tests
-        run: npx playwright test
-      - uses: actions/upload-artifact@v5
-        if: always()
-        with:
-          name: playwright-report
-          path: bingo-web/playwright-report/
-          retention-days: 30
-
   lint:
     needs: prepare
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -34,6 +34,9 @@ jobs:
   e2e:
     timeout-minutes: 10
     runs-on: ubuntu-latest
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:54322/postgres
+      DIRECT_URL: postgresql://postgres:postgres@127.0.0.1:54322/postgres
     steps:
       - name: コードをチェックアウト
         uses: actions/checkout@v5

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,69 @@
+name: E2E Tests
+
+on:
+  pull_request:
+    paths:
+      - "src/**"
+      - "e2e/**"
+      - "prisma/**"
+      - "public/**"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "playwright.config.ts"
+      - "next.config.js"
+      - "tsconfig.json"
+      - "postcss.config.js"
+    branches:
+      - main
+  push:
+    paths:
+      - "src/**"
+      - "e2e/**"
+      - "prisma/**"
+      - "public/**"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "playwright.config.ts"
+      - "next.config.js"
+      - "tsconfig.json"
+      - "postcss.config.js"
+    branches:
+      - main
+
+jobs:
+  e2e:
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    steps:
+      - name: コードをチェックアウト
+        uses: actions/checkout@v5
+      - name: pnpmをセットアップ
+        uses: pnpm/action-setup@v4
+      - name: Node.jsをセットアップ
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .node-version
+          cache: pnpm
+      - name: 依存関係をインストール
+        run: pnpm install
+      - name: Supabase CLIをセットアップ
+        uses: supabase/setup-cli@v1
+        with:
+          version: latest
+      - name: Supabaseを起動
+        run: supabase start
+      - name: Prismaマイグレーションを実行
+        run: pnpm prisma migrate deploy
+      - name: データベースにシードデータを投入
+        run: pnpm prisma db seed
+      - name: Playwrightブラウザをインストール
+        run: pnpm exec playwright install --only-shell
+      - name: E2Eテストを実行
+        run: pnpm playwright test
+      - name: テストレポートをアップロード
+        uses: actions/upload-artifact@v5
+        if: always()
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 5

--- a/e2e/bingo-game.test.ts
+++ b/e2e/bingo-game.test.ts
@@ -18,11 +18,15 @@ test("抽選した番号が履歴に記録される", async ({ page }) => {
 	await test.step("3回抽選を実行する", async () => {
 		for (let i = 0; i < 3; i++) {
 			await page.getByRole("button", { name: "スタート" }).click();
-			await expect(page.getByRole("button", { name: "ストップ" })).toBeVisible();
+			await expect(
+				page.getByRole("button", { name: "ストップ" }),
+			).toBeVisible();
 			await page.getByRole("button", { name: "ストップ" }).click();
 
 			// 抽選処理完了を待つ
-			await expect(page.getByRole("button", { name: "スタート" })).toBeVisible();
+			await expect(
+				page.getByRole("button", { name: "スタート" }),
+			).toBeVisible();
 
 			// 抽選番号を記録
 			const lotteryNumberLocator = page.getByRole("status", {

--- a/e2e/bingo-game.test.ts
+++ b/e2e/bingo-game.test.ts
@@ -1,0 +1,111 @@
+import { expect, test } from "@playwright/test";
+
+test("抽選した番号が履歴に記録される", async ({ page }) => {
+	await test.step("ゲームを開始する", async () => {
+		await page.goto("/");
+		await page.getByRole("button", { name: "ビンゴゲームを開始する" }).click();
+	});
+
+	await test.step("初期状態を確認する", async () => {
+		const lotteryNumberLocator = page.getByRole("status", {
+			name: "抽選結果",
+		});
+		await expect(lotteryNumberLocator).toHaveText("-");
+	});
+
+	const drawnNumbers: string[] = [];
+
+	await test.step("3回抽選を実行する", async () => {
+		for (let i = 0; i < 3; i++) {
+			await page.getByRole("button", { name: "スタート" }).click();
+			await expect(page.getByRole("button", { name: "ストップ" })).toBeVisible();
+			await page.getByRole("button", { name: "ストップ" }).click();
+
+			// 抽選処理完了を待つ
+			await expect(page.getByRole("button", { name: "スタート" })).toBeVisible();
+
+			// 抽選番号を記録
+			const lotteryNumberLocator = page.getByRole("status", {
+				name: "抽選結果",
+			});
+			const number = (await lotteryNumberLocator.textContent()) ?? "";
+			drawnNumbers.push(number);
+		}
+	});
+
+	await test.step("抽選履歴に番号が古い順で記録されている", async () => {
+		const historyRegion = page.getByRole("region", { name: "抽選履歴" });
+		const historyItems = historyRegion.getByRole("listitem");
+
+		// 履歴が3件表示されている
+		await expect(historyItems).toHaveCount(3);
+
+		// 履歴の順序を確認（古い順＝抽選した順番）
+		await expect(historyItems.nth(0)).toHaveText(drawnNumbers[0]);
+		await expect(historyItems.nth(1)).toHaveText(drawnNumbers[1]);
+		await expect(historyItems.nth(2)).toHaveText(drawnNumbers[2]);
+	});
+});
+
+test("75回抽選すると抽選終了になる", async ({ page }) => {
+	await test.step("74回抽選済みのゲームにアクセスする", async () => {
+		await page.goto("/games/12345678-1234-5678-1234-567812345678");
+	});
+
+	await test.step("抽選履歴が74個表示されている（永続化の確認）", async () => {
+		const historyRegion = page.getByRole("region", { name: "抽選履歴" });
+		await expect(historyRegion.getByRole("listitem")).toHaveCount(74);
+	});
+
+	await test.step("スタートボタンが活性状態である（継続可能の確認）", async () => {
+		const startButton = page.getByRole("button", { name: "スタート" });
+		await expect(startButton).toBeEnabled();
+	});
+
+	await test.step("75回目の抽選を実行する", async () => {
+		const startButton = page.getByRole("button", { name: "スタート" });
+		await startButton.click();
+		await page.getByRole("button", { name: "ストップ" }).click();
+
+		const lotteryNumberLocator = page.getByRole("status", {
+			name: "抽選結果",
+		});
+		await expect(lotteryNumberLocator).toHaveText(/^[1-9][0-9]?$/);
+	});
+
+	await test.step("抽選履歴が75個になる", async () => {
+		const historyRegion = page.getByRole("region", { name: "抽選履歴" });
+		await expect(historyRegion.getByRole("listitem")).toHaveCount(75);
+	});
+
+	await test.step("スタートボタンが「抽選終了」で非活性になる", async () => {
+		await expect(page.getByRole("button", { name: "抽選終了" })).toBeDisabled();
+	});
+});
+
+test("サウンド設定を切り替えられる", async ({ page }) => {
+	await test.step("ゲームを開始する", async () => {
+		await page.goto("/");
+		await page.getByRole("button", { name: "ビンゴゲームを開始する" }).click();
+	});
+
+	let soundSwitch: ReturnType<typeof page.getByRole>;
+	await test.step("サウンド設定がデフォルトでONになっている", async () => {
+		soundSwitch = page.getByRole("switch", { name: "サウンド設定" });
+		await expect(soundSwitch).toBeChecked();
+	});
+
+	await test.step("スイッチをOFFに切り替える", async () => {
+		await soundSwitch.click();
+		await expect(soundSwitch).not.toBeChecked();
+	});
+
+	await test.step("スイッチをONに切り替える", async () => {
+		await soundSwitch.click();
+		await expect(soundSwitch).toBeChecked();
+	});
+
+	// TODO: 音声が実際に鳴っているかの確認
+	// - サウンドON時：ルーレット中に音声が鳴る
+	// - サウンドOFF時：ルーレット中に音声が鳴らない
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,21 +6,21 @@ import { defineConfig, devices } from "@playwright/test";
  */
 // require('dotenv').config();
 
-const testServerUrl = "http://localhost:3001/";
+const testServerUrl = "http://localhost:3000/";
 
 /**
  * See https://playwright.dev/docs/test-configuration.
  */
 export default defineConfig({
-	testDir: "./src/app",
+	testDir: "./e2e",
 	/* Run tests in files in parallel */
-	fullyParallel: true,
+	fullyParallel: false,
 	/* Fail the build on CI if you accidentally left test.only in the source code. */
 	forbidOnly: !!process.env.CI,
 	/* Retry on CI only */
 	retries: process.env.CI ? 2 : 0,
 	/* Opt out of parallel tests on CI. */
-	workers: process.env.CI ? 1 : undefined,
+	workers: 1,
 	/* Reporter to use. See https://playwright.dev/docs/test-reporters */
 	reporter: "html",
 	/* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
@@ -70,10 +70,9 @@ export default defineConfig({
 		// },
 	],
 
-	// /* Run your local dev server before starting the tests */
+	/* Run your local dev server before starting the tests */
 	webServer: {
-		command:
-			"INFRA=INMEMORY npm run build && PORT=3001 INFRA=INMEMORY npm start",
+		command: "pnpm run build && PORT=3000 pnpm start",
 		url: testServerUrl,
 		reuseExistingServer: !process.env.CI,
 	},

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,3 +1,38 @@
-export async function main() {}
+import { PrismaClient } from "../src/app/generated/prisma";
 
-main();
+const prisma = new PrismaClient();
+
+export async function main() {
+	console.log("Starting seed...");
+
+	// 既存データのクリーンアップ
+	await prisma.bingoCardEntity.deleteMany();
+	await prisma.bingoGameEntity.deleteMany();
+
+	// 74回抽選済みのテストゲームを作成
+	const lotteryNumbers74 = Array.from({ length: 74 }, (_, i) => i + 1);
+
+	const game74Draws = await prisma.bingoGameEntity.create({
+		data: {
+			id: "12345678-1234-5678-1234-567812345678",
+			viewId: "87654321-4321-8765-4321-876543218765",
+			lotteryNumbers: lotteryNumbers74,
+			sound: true,
+		},
+	});
+
+	console.log("Seed completed successfully");
+	console.log("Created game:", {
+		id: game74Draws.id,
+		drawCount: game74Draws.lotteryNumbers.length,
+	});
+}
+
+main()
+	.catch((e) => {
+		console.error("Seed failed:", e);
+		process.exit(1);
+	})
+	.finally(async () => {
+		await prisma.$disconnect();
+	});

--- a/src/app/(noRobots)/games/[bingoGameId]/page.tsx
+++ b/src/app/(noRobots)/games/[bingoGameId]/page.tsx
@@ -1,6 +1,6 @@
 import { ReloadIcon } from "@radix-ui/react-icons";
 import { cacheLife, cacheTag } from "next/cache";
-import { Suspense } from "react";
+import { Suspense, useId } from "react";
 import { CACHE_TAGS } from "@/lib/cache-tags";
 import { getSoundSetting } from "./get-sound-setting";
 import { LotteryHistoryContainer } from "./lottery-history";
@@ -12,6 +12,7 @@ export default async function BingoGameLotteryPage({
 	params,
 }: PageProps<"/games/[bingoGameId]">) {
 	const bingoGameId = params.then(({ bingoGameId }) => bingoGameId);
+	const lotteryHistoryHeadingId = useId();
 
 	return (
 		<div>
@@ -22,13 +23,16 @@ export default async function BingoGameLotteryPage({
 			>
 				<LotteryRouletteContainer bingoGameId={bingoGameId} />
 			</Suspense>
-			<div className="my-8">
+			<section className="my-8" aria-labelledby={lotteryHistoryHeadingId}>
+				<h2 className="text-center mb-2" id={lotteryHistoryHeadingId}>
+					抽選履歴
+				</h2>
 				<Suspense
 					fallback={<ReloadIcon className="mx-auto h-12 w-12 animate-spin" />}
 				>
 					<LotteryHistoryContainer bingoGameId={bingoGameId} />
 				</Suspense>
-			</div>
+			</section>
 			<Suspense fallback={<SoundSetting bingoGameId="" sound disabled />}>
 				<SoundSettingContainer bingoGameId={bingoGameId} />
 			</Suspense>


### PR DESCRIPTION
## 概要
ビンゴゲームの抽選ページに対するe2eテストを実装しました。

## 実装内容

### テストケース
1. **抽選した番号が履歴に記録される**
   - 3回の抽選を実行し、履歴が古い順に記録されることを確認
   
2. **75回抽選すると抽選終了になる**
   - 74回抽選済みゲームから継続し、75回目で抽選終了ボタンが非活性になることを確認
   
3. **サウンド設定を切り替えられる**
   - サウンド設定のON/OFF切り替えを確認（音声確認はTODO）

### テスト環境
- Playwright使用
- Supabase + Prismaで実際のDBを使用
- Prisma seedで74回抽選済みテストデータを準備

### CI/CD
- GitHub Actionsでe2eテスト専用ワークフロー（`.github/workflows/e2e.yml`）を追加
- Supabase起動、マイグレーション、seed投入を自動化
- テストレポートを5日間保存

## テスト実行方法

### ローカル
```bash
# Supabaseを起動
supabase start

# マイグレーション & seed
pnpm prisma migrate deploy
pnpm prisma db seed

# e2eテスト実行
pnpm playwright test
```

## 主な変更ファイル
- `e2e/bingo-game.test.ts` - e2eテスト
- `.github/workflows/e2e.yml` - CI/CDワークフロー
- `prisma/seed.ts` - テストデータ
- `playwright.config.ts` - Playwright設定

🤖 Generated with [Claude Code](https://claude.com/claude-code)