### PR TITLE
M_PLUS_Rounded_1c をシステムネイティブフォントに変更

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -127,14 +127,11 @@
 		--input: 12 6.5% 15.1%;
 		--ring: 35.5 91.7% 32.9%;
 	}
-}
 
-@layer base {
 	body {
 		@apply bg-background text-foreground;
-		font-family: "Hiragino Maru Gothic ProN", "Hiragino Maru Gothic Pro",
-			"BIZ UDPGothic", "Rounded Mplus 1c", "M PLUS Rounded 1c",
-			-apple-system, BlinkMacSystemFont, "Segoe UI", "Yu Gothic UI", Meiryo,
-			"Noto Sans CJK JP", sans-serif;
+		font-family:
+			"Hiragino Maru Gothic ProN", "Hiragino Maru Gothic Pro", "BIZ UDPGothic",
+			"Yu Gothic UI", Meiryo, "Noto Sans CJK JP", "Noto Sans JP", sans-serif;
 	}
 }

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -132,5 +132,9 @@
 @layer base {
 	body {
 		@apply bg-background text-foreground;
+		font-family: "Hiragino Maru Gothic ProN", "Hiragino Maru Gothic Pro",
+			"BIZ UDPGothic", "Rounded Mplus 1c", "M PLUS Rounded 1c",
+			-apple-system, BlinkMacSystemFont, "Segoe UI", "Yu Gothic UI", Meiryo,
+			"Noto Sans CJK JP", sans-serif;
 	}
 }

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -2,7 +2,7 @@ import "./globals.css";
 
 import { GoogleAnalytics } from "@next/third-parties/google";
 import type { Metadata, Viewport } from "next";
-import { M_PLUS_Rounded_1c, Montserrat } from "next/font/google";
+import { Montserrat } from "next/font/google";
 import Image from "next/image";
 import Link from "next/link";
 import { Toaster } from "@/components/ui/toaster";
@@ -45,11 +45,6 @@ const titleFont = Montserrat({
 	weight: "400",
 });
 
-const baseFont = M_PLUS_Rounded_1c({
-	subsets: ["latin"],
-	weight: "400",
-});
-
 export default function RootLayout({
 	children,
 }: {
@@ -57,12 +52,7 @@ export default function RootLayout({
 }) {
 	return (
 		<html lang="ja">
-			<body
-				className={cn(
-					baseFont.className,
-					"flex h-dvh flex-col overflow-hidden",
-				)}
-			>
+			<body className={cn("flex h-dvh flex-col overflow-hidden")}>
 				<header className="relative z-10 flex justify-center bg-background px-4 py-2 shadow-md">
 					<Image src={Mark} alt="" width="30" height="30" className="mr-2" />
 					<h1


### PR DESCRIPTION
## Summary

- Web フォントの M_PLUS_Rounded_1c を削除し、丸ゴシック系のシステムネイティブフォントスタックに変更
- 各プラットフォーム（Mac/iOS, Windows, Android）で丸ゴシック体またはそれに近いフォントを優先的に使用
- タイトル用の Montserrat フォントはそのまま維持

### フォントスタック
- **Mac/iOS**: Hiragino Maru Gothic ProN（ヒラギノ丸ゴ）
- **Windows**: BIZ UDPGothic または Yu Gothic UI、Meiryo
- **Android**: Noto Sans CJK JP
- **その他**: システムのデフォルト sans-serif

## Test plan

- [ ] Mac/iOS でフォント表示を確認
- [ ] Windows でフォント表示を確認
- [ ] Android でフォント表示を確認
- [ ] タイトル部分の Montserrat が正しく表示されることを確認
- [ ] 全体的なデザインが崩れていないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)